### PR TITLE
upgraded docker compose wait

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -9,7 +9,8 @@ RUN go mod download
 RUN go get github.com/githubnemo/CompileDaemon
 
 # Following lines provides ability to add WAIT_HOSTS in docker-compose to wait for other hosts to start
-ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.7.3/wait /wait
+# All configuration options are available here: https://github.com/ufoscout/docker-compose-wait#additional-configuration-options
+ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait /wait
 RUN chmod +x /wait
 
 ENTRYPOINT /wait && CompileDaemon -exclude-dir=.git -exclude-dir=docs --build="go build main.go" --command="./main serve"

--- a/Dockerfile.migrate
+++ b/Dockerfile.migrate
@@ -7,7 +7,7 @@ COPY . .
 RUN go mod download
 
 # Following lines provides ability to add WAIT_HOSTS in docker-compose to wait for other hosts to start
-ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.7.3/wait /wait
+ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait /wait
 RUN chmod +x /wait
 
 ENTRYPOINT /wait && go build main.go && ./main migrate && ./main create-super-org && ./main migrate-templates


### PR DESCRIPTION
This is required to use `WAIT_TIMEOUT` to increase the default timeout of 30 seconds the service is waiting on the dependent services to start. We could use `WAIT_TIMEOUT` as an env variable in docker-compose for `bindu-migrate` service to increase the timeout to 300 seconds or more when it starts for the first time.